### PR TITLE
Fixed #1 - non-dojo inline loaders are left alone

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function preprocessModule(module, options, content){
     var modifiedContent = content.replace(domReadyRegExp, '/* $& */')
     var isModified = content.length !== modifiedContent.length;
     content = isModified ? 'require("domready")(function(){' + modifiedContent + '});' : content;
-    
+
     return content;
 }
 
@@ -165,7 +165,7 @@ function mapDependency(module, options, dep){
                 // Will be loaded via DojoWebpackLoader
                 break;
             default:
-                debugger;
+                result_loaders.push(norm_dep.loaders[i]);
                 break;
         }
     }


### PR DESCRIPTION
This was a simple fix, we just needed to add the loaders back in after parsing them out of the request path